### PR TITLE
Allow Symbols as nodeID

### DIFF
--- a/src/core/private/_generateEdgeIDFromSourceAndTargetIDs.js
+++ b/src/core/private/_generateEdgeIDFromSourceAndTargetIDs.js
@@ -1,4 +1,4 @@
 const generateEdgeIDFromSourceAndTargetIDs = ({ sourceID, targetID }) => {
-  return `${sourceID}_${targetID}`;
+  return `${String(sourceID)}_${String(targetID)}`;
 };
 module.exports = generateEdgeIDFromSourceAndTargetIDs;


### PR DESCRIPTION
The template literals doesn't work if the variables are `Symbol` s.
The `Symbol` should be casted to `String` before it's used in template strings.
